### PR TITLE
Set Fuse max_write to the kernel's allowed limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -341,6 +341,7 @@ func mount(file *mch.File, source, mountPoint string, config config) error {
 			Debug:      config.Debug,
 			FsName:     source,
 			Name:       "mchfuse",
+			MaxWrite:   fuse.MAX_KERNEL_WRITE,
 		},
 		UID:          uint32(config.UID),
 		GID:          uint32(config.GID),


### PR DESCRIPTION
Adds new entry in MountOptions setting the size of the writes.

Sets the value to the max possible allowed by fuse-kernel as that limit is quite low anyway (32 pages) and it avoids having it hardcoded or an extra configuration flag. Considering how heavy writes are in this fs it is unlikely that anyone would want smaller / more frequent writes than 128k.